### PR TITLE
Fix to organise arrow functions with methods close #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 out
 node_modules
-.vscode
 .vscode-test/
 *.vsix
 /.vscodeignore

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"eg2.tslint"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        ".vscode": false,
+        "node_modules": false,
+        ".git_ignore": false,
+        "out": false
+    },
+    "search.exclude": {
+        ".vscode": true,
+        "node_modules": true,
+        ".git_ignore": true,
+        "out": true
+    },
+    "cSpell.enabled": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Extensions supports the following configuration options:
 - `tsco.addRowNumberInRegionName`: When true region children count added on title. True by default.
 - `tsco.accessorsBeforeCtor`: When true put accessor before ctor during organization. False by default.
 - `tsco.memberOrder`: Configuration of grouping and ordering of members.
+- `tsco.treatArrowFunctionPropertiesAsMethods`: When true arrow function properties will be treated as methods.
 
 ### Configuration of grouping and ordering of members
 
@@ -291,3 +292,7 @@ Example of the default `tsco.memberOrder` setting:
 ### 10.0.16
 
 - fix bug where accessors (getters and setters) got removed when organizing a class
+
+### 10.0.17
+
+- added option to treat arrow function properties as methods (courtesy of [testpossessed](https://github.com/testpossessed))

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Organize currently opened TypeScript file or all TypeScript files in your projec
 
 From the command palette you can:
 
-* organize current TypeScript file by invoking command "TypeScript Class Organizer: Organize Current File",
-* organize all TypeScript files in the project by invoking command "TypeScript Class Organizer: Organize All Files"
+- organize current TypeScript file by invoking command "TypeScript Class Organizer: Organize Current File",
+- organize all TypeScript files in the project by invoking command "TypeScript Class Organizer: Organize All Files"
 
 ![Command Palette](./doc/command_palette.png "Command Palette")
 
@@ -35,269 +35,213 @@ You can invoke command "TypeScript Class Organizer: Organize Current File" by us
 
 Extensions supports the following configuration options:
 
-* `tsco.useRegions`: When true regions surounding member groups are added. True by default.
-* `tsco.addPublicModifierIfMissing`: When true public access modifier is added. True by default.
-* `tsco.addRegionIdentation`: When true regions are idented with class members. True by default.
-* `tsco.addRegionCaptionToRegionEnd`: When true region caption is added to region end as well. True by default.
-* `tsco.groupPropertiesWithDecorators`: When true properties with decorators will come first. False by default.
-* `tsco.addRowNumberInRegionName`: When true region children count added on title. True by default.
-* `tsco.accessorsBeforeCtor`: When true put accessor before ctor during organization. False by default.
-* `tsco.memberOrder`: Configuration of grouping and ordering of members.
+- `tsco.useRegions`: When true regions surrounding member groups are added. True by default.
+- `tsco.addPublicModifierIfMissing`: When true public access modifier is added. True by default.
+- `tsco.addRegionIndentation`: When true regions are indented with class members. True by default.
+- `tsco.addRegionCaptionToRegionEnd`: When true region caption is added to region end as well. True by default.
+- `tsco.groupPropertiesWithDecorators`: When true properties with decorators will come first. False by default.
+- `tsco.addRowNumberInRegionName`: When true region children count added on title. True by default.
+- `tsco.accessorsBeforeCtor`: When true put accessor before ctor during organization. False by default.
+- `tsco.memberOrder`: Configuration of grouping and ordering of members.
 
 ### Configuration of grouping and ordering of members
 
-By default members are groupped and ordered in the following way:
+By default members are grouped and ordered in the following way:
 
-* properties,
-  * private static const properties,
-  * private const properties,
-  * private static readonly properties,
-  * private readonly properties,
-  * private static properties,
-  * private properties,
-  * protected static const properties,
-  * protected const properties,
-  * protected static readonly properties,
-  * protected readonly properties,
-  * protected static properties,
-  * protected properties,
-  * public staticconst properties,
-  * public const properties,
-  * public static readonly properties,
-  * public readonly properties,
-  * public static properties,
-  * public properties,
-* constructors,
-* public static indexes,
-* public indexes,
-* public abstract indexes,
-* protected static indexes,
-* protected indexes,
-* protected abstract indexes,
-* private static indexes,
-* private indexes,
-* private abstract indexes,
-* public static accessors,
-* public accessors,
-* public abstract accessors,
-* protected static accessors,
-* protected accessors,
-* protected abstract accessors,
-* private static accessors,
-* private accessors,
-* private abstract accessors,
-* public static methods,
-* public methods,
-* public abstract methods,
-* protected static methods,
-* protected methods,
-* protected abstract methods,
-* private static methods,
-* private methods,
-* private abstract methods.
+- properties,
+  - private static const properties,
+  - private const properties,
+  - private static readonly properties,
+  - private readonly properties,
+  - private static properties,
+  - private properties,
+  - protected static const properties,
+  - protected const properties,
+  - protected static readonly properties,
+  - protected readonly properties,
+  - protected static properties,
+  - protected properties,
+  - public static const properties,
+  - public const properties,
+  - public static readonly properties,
+  - public readonly properties,
+  - public static properties,
+  - public properties,
+- constructors,
+- public static indexes,
+- public indexes,
+- public abstract indexes,
+- protected static indexes,
+- protected indexes,
+- protected abstract indexes,
+- private static indexes,
+- private indexes,
+- private abstract indexes,
+- public static accessors,
+- public accessors,
+- public abstract accessors,
+- protected static accessors,
+- protected accessors,
+- protected abstract accessors,
+- private static accessors,
+- private accessors,
+- private abstract accessors,
+- public static methods,
+- public methods,
+- public abstract methods,
+- protected static methods,
+- protected methods,
+- protected abstract methods,
+- private static methods,
+- private methods,
+- private abstract methods.
 
-This configuration can ge changed by using the `tsco.memberOrder` setting in settings.json. Members can be groupped seperately or groupped together with other member groups in a two level hierarchy. Every group has a property:
+This configuration can ge changed by using the `tsco.memberOrder` setting in settings.json. Members can be grouped separately or grouped together with other member groups in a two level hierarchy. Every group has a property:
 
-* `caption` (only for top level groups): the caption will be outputted if `tsco.useRegions` is set to true,
-* `memberType` (top and bottom level groups): the type of the member in the group (privateStaticConstProperties, privateConstProperties, privateStaticReadOnlyProperties, privateReadOnlyProperties, privateStaticProperties, privateProperties, protectedStaticConstProperties, protectedConstProperties, protectedStaticReadOnlyProperties, protectedReadOnlyProperties, protectedStaticProperties, protectedProperties, publicStaticConstProperties, publicConstProperties, publicStaticReadOnlyProperties, publicReadOnlyProperties, publicStaticProperties, publicProperties, constructors, publicStaticIndexes, publicIndexes,
-publicAbstractIndexes, protectedStaticIndexes, protectedIndexes, protectedAbstractIndexes, privateStaticIndexes, privateIndexes, privateAbstractIndexes, publicStaticMethods, publicMethods, publicAbstractMethods, protectedStaticMethods, protectedMethods, protectedAbstractMethods, privateStaticMethods, privateMethods, privateAbstractMethods),
-* `subGroups` (only for top level groups): the array of member types to be included in this group.
+- `caption` (only for top level groups): the caption will be outputted if `tsco.useRegions` is set to true,
+- `memberType` (top and bottom level groups): the type of the member in the group (privateStaticConstProperties, privateConstProperties, privateStaticReadOnlyProperties, privateReadOnlyProperties, privateStaticProperties, privateProperties, protectedStaticConstProperties, protectedConstProperties, protectedStaticReadOnlyProperties, protectedReadOnlyProperties, protectedStaticProperties, protectedProperties, publicStaticConstProperties, publicConstProperties, publicStaticReadOnlyProperties, publicReadOnlyProperties, publicStaticProperties, publicProperties, constructors, publicStaticIndexes, publicIndexes,
+  publicAbstractIndexes, protectedStaticIndexes, protectedIndexes, protectedAbstractIndexes, privateStaticIndexes, privateIndexes, privateAbstractIndexes, publicStaticMethods, publicMethods, publicAbstractMethods, protectedStaticMethods, protectedMethods, protectedAbstractMethods, privateStaticMethods, privateMethods, privateAbstractMethods),
+- `subGroups` (only for top level groups): the array of member types to be included in this group.
 
 Example of the default `tsco.memberOrder` setting:
 
-``` json
+```json
 [
-    {
-        "caption": "Properties",
-        "memberTypes": [
-            "privateStaticConstProperties",
-            "privateConstProperties",
-            "privateStaticReadOnlyProperties",
-            "privateReadOnlyProperties",
-            "privateStaticProperties",
-            "privateProperties",
-            "protectedStaticConstProperties",
-            "protectedConstProperties",
-            "protectedStaticReadOnlyProperties",
-            "protectedReadOnlyProperties",
-            "protectedStaticProperties",
-            "protectedProperties",
-            "publicStaticConstProperties",
-            "publicConstProperties",
-            "publicStaticReadOnlyProperties",
-            "publicReadOnlyProperties",
-            "publicStaticProperties",
-            "publicProperties"
-        ]
-    },
-    {
-        "caption": "Constructors",
-        "memberTypes": [
-            "constructors"
-        ]
-    },
-    {
-        "caption": "Public Static Indexers",
-        "memberTypes": [
-            "publicStaticIndexes"
-        ]
-    },
-    {
-        "caption": "Public Indexers",
-        "memberTypes": [
-            "publicIndexes"
-        ]
-    },
-    {
-        "caption": "Public Abstract Indexers",
-        "memberTypes": [
-            "publicAbstractIndexes"
-        ]
-    },
-    {
-        "caption": "Protected Static Indexers",
-        "memberTypes": [
-            "protectedStaticIndexes"
-        ]
-    },
-    {
-        "caption": "Protected Indexers",
-        "memberTypes": [
-            "protectedIndexes"
-        ]
-    },
-    {
-        "caption": "Protected Abstract Indexers",
-        "memberTypes": [
-            "protectedAbstractIndexes"
-        ]
-    },
-    {
-        "caption": "Private Static Indexers",
-        "memberTypes": [
-            "privateStaticIndexes"
-        ]
-    },
-    {
-        "caption": "Private Indexers",
-        "memberTypes": [
-            "privateIndexes"
-        ]
-    },
-    {
-        "caption": "Private Abstract Indexers",
-        "memberTypes": [
-            "privateAbstractIndexes"
-        ]
-    },
-    {
-        "caption": "Public Static Accessors",
-        "memberTypes": [
-            "publicStaticGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Public Accessors",
-        "memberTypes": [
-            "publicGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Public Abstract Accessors",
-        "memberTypes": [
-            "publicAbstractGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Protected Static Accessors",
-        "memberTypes": [
-            "protectedStaticGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Protected Accessors",
-        "memberTypes": [
-            "protectedGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Protected Abstract Accessors",
-        "memberTypes": [
-            "protectedAbstractGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Private Static Accessors",
-        "memberTypes": [
-            "privateStaticGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Private Accessors",
-        "memberTypes": [
-            "privateGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Private Abstract Accessors",
-        "memberTypes": [
-            "privateAbstractGettersAndSetters"
-        ]
-    },
-    {
-        "caption": "Public Static Methods",
-        "memberTypes": [
-            "publicStaticMethods"
-        ]
-    },
-    {
-        "caption": "Public Methods",
-        "memberTypes": [
-            "publicMethods"
-        ]
-    },
-    {
-        "caption": "Public Abstract Methods",
-        "memberTypes": [
-            "publicAbstractMethods"
-        ]
-    },
-    {
-        "caption": "Protected Static Methods",
-        "memberTypes": [
-            "protectedStaticMethods"
-        ]
-    },
-    {
-        "caption": "Protected Methods",
-        "memberTypes": [
-            "protectedMethods"
-        ]
-    },
-    {
-        "caption": "Protected Abstract Methods",
-        "memberTypes": [
-            "protectedAbstractMethods"
-        ]
-    },
-    {
-        "caption": "Private Static Methods",
-        "memberTypes": [
-            "privateStaticMethods"
-        ]
-    },
-    {
-        "caption": "Private Methods",
-        "memberTypes": [
-            "privateMethods"
-        ]
-    },
-    {
-        "caption": "Private Abstract Methods",
-        "memberTypes": [
-            "privateAbstractMethods"
-        ]
-    }
+  {
+    "caption": "Properties",
+    "memberTypes": [
+      "privateStaticConstProperties",
+      "privateConstProperties",
+      "privateStaticReadOnlyProperties",
+      "privateReadOnlyProperties",
+      "privateStaticProperties",
+      "privateProperties",
+      "protectedStaticConstProperties",
+      "protectedConstProperties",
+      "protectedStaticReadOnlyProperties",
+      "protectedReadOnlyProperties",
+      "protectedStaticProperties",
+      "protectedProperties",
+      "publicStaticConstProperties",
+      "publicConstProperties",
+      "publicStaticReadOnlyProperties",
+      "publicReadOnlyProperties",
+      "publicStaticProperties",
+      "publicProperties"
+    ]
+  },
+  {
+    "caption": "Constructors",
+    "memberTypes": ["constructors"]
+  },
+  {
+    "caption": "Public Static Indexers",
+    "memberTypes": ["publicStaticIndexes"]
+  },
+  {
+    "caption": "Public Indexers",
+    "memberTypes": ["publicIndexes"]
+  },
+  {
+    "caption": "Public Abstract Indexers",
+    "memberTypes": ["publicAbstractIndexes"]
+  },
+  {
+    "caption": "Protected Static Indexers",
+    "memberTypes": ["protectedStaticIndexes"]
+  },
+  {
+    "caption": "Protected Indexers",
+    "memberTypes": ["protectedIndexes"]
+  },
+  {
+    "caption": "Protected Abstract Indexers",
+    "memberTypes": ["protectedAbstractIndexes"]
+  },
+  {
+    "caption": "Private Static Indexers",
+    "memberTypes": ["privateStaticIndexes"]
+  },
+  {
+    "caption": "Private Indexers",
+    "memberTypes": ["privateIndexes"]
+  },
+  {
+    "caption": "Private Abstract Indexers",
+    "memberTypes": ["privateAbstractIndexes"]
+  },
+  {
+    "caption": "Public Static Accessors",
+    "memberTypes": ["publicStaticGettersAndSetters"]
+  },
+  {
+    "caption": "Public Accessors",
+    "memberTypes": ["publicGettersAndSetters"]
+  },
+  {
+    "caption": "Public Abstract Accessors",
+    "memberTypes": ["publicAbstractGettersAndSetters"]
+  },
+  {
+    "caption": "Protected Static Accessors",
+    "memberTypes": ["protectedStaticGettersAndSetters"]
+  },
+  {
+    "caption": "Protected Accessors",
+    "memberTypes": ["protectedGettersAndSetters"]
+  },
+  {
+    "caption": "Protected Abstract Accessors",
+    "memberTypes": ["protectedAbstractGettersAndSetters"]
+  },
+  {
+    "caption": "Private Static Accessors",
+    "memberTypes": ["privateStaticGettersAndSetters"]
+  },
+  {
+    "caption": "Private Accessors",
+    "memberTypes": ["privateGettersAndSetters"]
+  },
+  {
+    "caption": "Private Abstract Accessors",
+    "memberTypes": ["privateAbstractGettersAndSetters"]
+  },
+  {
+    "caption": "Public Static Methods",
+    "memberTypes": ["publicStaticMethods"]
+  },
+  {
+    "caption": "Public Methods",
+    "memberTypes": ["publicMethods"]
+  },
+  {
+    "caption": "Public Abstract Methods",
+    "memberTypes": ["publicAbstractMethods"]
+  },
+  {
+    "caption": "Protected Static Methods",
+    "memberTypes": ["protectedStaticMethods"]
+  },
+  {
+    "caption": "Protected Methods",
+    "memberTypes": ["protectedMethods"]
+  },
+  {
+    "caption": "Protected Abstract Methods",
+    "memberTypes": ["protectedAbstractMethods"]
+  },
+  {
+    "caption": "Private Static Methods",
+    "memberTypes": ["privateStaticMethods"]
+  },
+  {
+    "caption": "Private Methods",
+    "memberTypes": ["privateMethods"]
+  },
+  {
+    "caption": "Private Abstract Methods",
+    "memberTypes": ["privateAbstractMethods"]
+  }
 ]
 ```
 
@@ -305,45 +249,45 @@ Example of the default `tsco.memberOrder` setting:
 
 ### 1.0.0
 
-* Initial release.
+- Initial release.
 
 ### 1.0.9
 
-* added add public modifier if missing option
-* added add region identation option
-* added end region caption option
-* added organiting type aliases, interfaces, classes and functions
-* fixed issue with identation tabs / spaces
-* fixed issue when comments were preceding class members
-* fixed issue when decorators were preceding class members
-* fixed issue with removing redundant empty lines
-* updated referenced packages
+- added add public modifier if missing option
+- added add region Indentation option
+- added end region caption option
+- added organizing type aliases, interfaces, classes and functions
+- fixed issue with Indentation tabs / spaces
+- fixed issue when comments were preceding class members
+- fixed issue when decorators were preceding class members
+- fixed issue with removing redundant empty lines
+- updated referenced packages
 
 ### 1.0.10
 
-* added group properties with decorators option
+- added group properties with decorators option
 
 ### 1.0.11
 
-* fixed issue with duplicated regions
-* addded grouping by decorator for all elements, not just properties when grouping by decorators
-* added a new line between group with decorators and group without decorators when grouping by decorators
+- fixed issue with duplicated regions
+- addded grouping by decorator for all elements, not just properties when grouping by decorators
+- added a new line between group with decorators and group without decorators when grouping by decorators
 
 ### 1.0.12
 
-* removed limitation where extension can be activated only when not in debug mode
-* fixed bug where redundant empty lines were not removed correctly
-* fix bug where public access modifier was not added to methods
+- removed limitation where extension can be activated only when not in debug mode
+- fixed bug where redundant empty lines were not removed correctly
+- fix bug where public access modifier was not added to methods
 
 ### 1.0.14
 
-* added option of adding number of members within a region (courtesy of [pillont](https://github.com/pillont))
-* added option to output accessors before constructor (courtesy of [pillont](https://github.com/pillont))
+- added option of adding number of members within a region (courtesy of [pillont](https://github.com/pillont))
+- added option to output accessors before constructor (courtesy of [pillont](https://github.com/pillont))
 
 ### 10.0.15
 
-* add option to customize grouping and ordering of members
+- add option to customize grouping and ordering of members
 
 ### 10.0.16
 
-* fix bug where accessors (getters and setters) got removed when organizing a class
+- fix bug where accessors (getters and setters) got removed when organizing a class

--- a/extension.ts
+++ b/extension.ts
@@ -244,6 +244,13 @@ function print(groups: ElementNodeGroup[], sourceCode: string, start: number, en
                     {
                         members += newLine;
                     }
+                    else if (nodeGroup.length - 1 > i &&
+                        nodeGroup[i] instanceof PropertyNode &&
+                        nodeGroup[i + 1] instanceof MethodNode)
+                    {
+                        // arrow function property folowed by a method -> add a new line in between
+                        members += newLine;
+                    }
                 }
 
                 members += newLine;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsco",
-  "version": "1.0.12",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1530,9 +1530,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -24,28 +24,34 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
+      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
       "dev": true
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "agent-base": {
@@ -70,15 +76,26 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
@@ -175,12 +192,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -211,12 +222,12 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -248,12 +259,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -344,9 +349,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "es6-promise": {
@@ -371,9 +376,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -383,19 +388,19 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -404,7 +409,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -426,12 +431,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -441,13 +446,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
+      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -458,9 +463,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -482,9 +487,9 @@
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "extend": {
@@ -529,9 +534,9 @@
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -625,10 +630,13 @@
       }
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+      "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "growl": {
       "version": "1.10.5",
@@ -739,9 +747,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -771,24 +779,85 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
+      "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "is-extglob": {
@@ -798,9 +867,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -926,9 +995,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -1027,9 +1096,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "natural-compare": {
@@ -1060,26 +1129,26 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-tmpdir": {
@@ -1107,12 +1176,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "performance-now": {
@@ -1197,15 +1260,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
-    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1213,12 +1267,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -1232,18 +1286,18 @@
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -1297,6 +1351,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -1339,22 +1401,23 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -1403,6 +1466,18 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -1456,54 +1531,10 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
-    },
-    "tslint": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
-      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
-    "tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -1528,6 +1559,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "typescript": {
       "version": "3.8.3",
@@ -1618,10 +1655,10 @@
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tsco",
     "displayName": "TypeScript Class Organizer",
     "description": "Groups and orders class members",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "publisher": "aljazsim",
     "author": {
         "name": "aljazsim",
@@ -374,13 +374,14 @@
             }
         ]
     },
-    "main": "./out/extension",
+    "main": "./out/extension.js",
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
+        "test": "npm run compile && node ./node_modules/vscode/bin/test",
+        "package": "npx vsce package"
     },
     "devDependencies": {
         "@types/mocha": "5.2.7",
@@ -390,6 +391,6 @@
         "vscode": "1.1.36"
     },
     "dependencies": {
-        "typescript": "3.6.3"
+        "typescript": "^3.8.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,396 +1,399 @@
 {
-    "name": "tsco",
-    "displayName": "TypeScript Class Organizer",
-    "description": "Groups and orders class members",
-    "version": "1.0.17",
-    "publisher": "aljazsim",
-    "author": {
-        "name": "aljazsim",
-        "url": "https://github.com/aljazsim/"
-    },
-    "icon": "doc/logo.png",
-    "galleryBanner": {
-        "color": "#4c725d",
-        "theme": "dark"
-    },
-    "bugs": {
-        "url": "https://github.com/aljazsim/vs-code-typescript-class-organizer/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/aljazsim/vs-code-typescript-class-organizer.git"
-    },
-    "homepage": "https://github.com/aljazsim/vs-code-typescript-class-organizer",
-    "engines": {
-        "vscode": "^1.22.0"
-    },
-    "license": "MIT",
-    "categories": [
-        "Formatters"
-    ],
-    "keywords": [
-        "TypeScript",
-        "organize",
-        "order",
-        "class",
-        "regions"
-    ],
-    "activationEvents": [
-        "onCommand:tsco.organize",
-        "onCommand:tsco.organizeAll"
-    ],
-    "contributes": {
-        "configuration": {
-            "title": "Typescript Class Organizer configuration",
-            "properties": {
-                "tsco.useRegions": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Adds regions when organizing a class."
-                },
-                "tsco.addRowNumberInRegionName": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Add region children count on title."
-                },
-                "tsco.accessorsBeforeCtor": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "during organization : put accessor before ctor."
-                },
-                "tsco.addPublicModifierIfMissing": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Adds a public acccess modifier if missing."
-                },
-                "tsco.addRegionIdentation": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Adds region identation."
-                },
-                "tsco.addRegionCaptionToRegionEnd": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Adds region caption to region end."
-                },
-                "tsco.groupPropertiesWithDecorators": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When true properties with decorators will come first."
-                },
-                "tsco.memberOrder": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "title": "member group",
-                        "properties": {
-                            "caption": {
-                                "type": "string",
-                                "description": "Group caption (outputed in the region name if this goroup is a region and if using regions)."
-                            },
-                            "memberTypes": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "description": "Type of the member (avoid using duplicated member types).",
-                                    "enum": [
-                                        "privateStaticConstProperties",
-                                        "privateConstProperties",
-                                        "privateStaticReadOnlyProperties",
-                                        "privateReadOnlyProperties",
-                                        "privateStaticProperties",
-                                        "privateProperties",
-                                        "protectedStaticConstProperties",
-                                        "protectedConstProperties",
-                                        "protectedStaticReadOnlyProperties",
-                                        "protectedReadOnlyProperties",
-                                        "protectedStaticProperties",
-                                        "protectedProperties",
-                                        "publicStaticConstProperties",
-                                        "publicConstProperties",
-                                        "publicStaticReadOnlyProperties",
-                                        "publicReadOnlyProperties",
-                                        "publicStaticProperties",
-                                        "publicProperties",
-                                        "constructors",
-                                        "publicStaticIndexes",
-                                        "publicIndexes",
-                                        "publicAbstractIndexes",
-                                        "protectedStaticIndexes",
-                                        "protectedIndexes",
-                                        "protectedAbstractIndexes",
-                                        "privateStaticIndexes",
-                                        "privateIndexes",
-                                        "privateAbstractIndexes",
-                                        "publicStaticMethods",
-                                        "publicMethods",
-                                        "publicAbstractMethods",
-                                        "protectedStaticMethods",
-                                        "protectedMethods",
-                                        "protectedAbstractMethods",
-                                        "privateStaticMethods",
-                                        "privateMethods",
-                                        "privateAbstractMethods"
-                                    ]
-                                }
-                            },
-                            "default": [],
-                            "description": "Nested member type sub-groups."
-                        }
-                    },
-                    "default": [
-                        {
-                            "caption": "Properties",
-                            "memberTypes": [
-                                "privateStaticConstProperties",
-                                "privateConstProperties",
-                                "privateStaticReadOnlyProperties",
-                                "privateReadOnlyProperties",
-                                "privateStaticProperties",
-                                "privateProperties",
-                                "protectedStaticConstProperties",
-                                "protectedConstProperties",
-                                "protectedStaticReadOnlyProperties",
-                                "protectedReadOnlyProperties",
-                                "protectedStaticProperties",
-                                "protectedProperties",
-                                "publicStaticConstProperties",
-                                "publicConstProperties",
-                                "publicStaticReadOnlyProperties",
-                                "publicReadOnlyProperties",
-                                "publicStaticProperties",
-                                "publicProperties"
-                            ]
-                        },
-                        {
-                            "caption": "Constructors",
-                            "memberTypes": [
-                                "constructors"
-                            ]
-                        },
-                        {
-                            "caption": "Public Static Indexers",
-                            "memberTypes": [
-                                "publicStaticIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Public Indexers",
-                            "memberTypes": [
-                                "publicIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Public Abstract Indexers",
-                            "memberTypes": [
-                                "publicAbstractIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Static Indexers",
-                            "memberTypes": [
-                                "protectedStaticIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Indexers",
-                            "memberTypes": [
-                                "protectedIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Abstract Indexers",
-                            "memberTypes": [
-                                "protectedAbstractIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Private Static Indexers",
-                            "memberTypes": [
-                                "privateStaticIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Private Indexers",
-                            "memberTypes": [
-                                "privateIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Private Abstract Indexers",
-                            "memberTypes": [
-                                "privateAbstractIndexes"
-                            ]
-                        },
-                        {
-                            "caption": "Public Static Accessors",
-                            "memberTypes": [
-                                "publicStaticGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Public Accessors",
-                            "memberTypes": [
-                                "publicGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Public Abstract Accessors",
-                            "memberTypes": [
-                                "publicAbstractGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Static Accessors",
-                            "memberTypes": [
-                                "protectedStaticGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Accessors",
-                            "memberTypes": [
-                                "protectedGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Abstract Accessors",
-                            "memberTypes": [
-                                "protectedAbstractGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Private Static Accessors",
-                            "memberTypes": [
-                                "privateStaticGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Private Accessors",
-                            "memberTypes": [
-                                "privateGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Private Abstract Accessors",
-                            "memberTypes": [
-                                "privateAbstractGettersAndSetters"
-                            ]
-                        },
-                        {
-                            "caption": "Public Static Methods",
-                            "memberTypes": [
-                                "publicStaticMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Public Methods",
-                            "memberTypes": [
-                                "publicMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Public Abstract Methods",
-                            "memberTypes": [
-                                "publicAbstractMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Static Methods",
-                            "memberTypes": [
-                                "protectedStaticMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Methods",
-                            "memberTypes": [
-                                "protectedMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Protected Abstract Methods",
-                            "memberTypes": [
-                                "protectedAbstractMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Private Static Methods",
-                            "memberTypes": [
-                                "privateStaticMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Private Methods",
-                            "memberTypes": [
-                                "privateMethods"
-                            ]
-                        },
-                        {
-                            "caption": "Private Abstract Methods",
-                            "memberTypes": [
-                                "privateAbstractMethods"
-                            ]
-                        }
-                    ],
-                    "description": "Order of member types."
-                }
-            }
+  "name": "tsco",
+  "displayName": "TypeScript Class Organizer",
+  "description": "Groups and orders class members",
+  "version": "1.0.17",
+  "publisher": "aljazsim",
+  "author": {
+    "name": "aljazsim",
+    "url": "https://github.com/aljazsim/"
+  },
+  "icon": "doc/logo.png",
+  "galleryBanner": {
+    "color": "#4c725d",
+    "theme": "dark"
+  },
+  "bugs": {
+    "url": "https://github.com/aljazsim/vs-code-typescript-class-organizer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aljazsim/vs-code-typescript-class-organizer.git"
+  },
+  "homepage": "https://github.com/aljazsim/vs-code-typescript-class-organizer",
+  "engines": {
+    "vscode": "^1.22.0"
+  },
+  "license": "MIT",
+  "categories": [
+    "Formatters"
+  ],
+  "keywords": [
+    "TypeScript",
+    "organize",
+    "order",
+    "class",
+    "regions"
+  ],
+  "activationEvents": [
+    "onCommand:tsco.organize",
+    "onCommand:tsco.organizeAll"
+  ],
+  "contributes": {
+    "configuration": {
+      "title": "Typescript Class Organizer configuration",
+      "properties": {
+        "tsco.useRegions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds regions when organizing a class."
         },
-        "commands": [
+        "tsco.addRowNumberInRegionName": {
+          "type": "boolean",
+          "default": true,
+          "description": "Add region children count on title."
+        },
+        "tsco.accessorsBeforeCtor": {
+          "type": "boolean",
+          "default": false,
+          "description": "during organization : put accessor before ctor."
+        },
+        "tsco.addPublicModifierIfMissing": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds a public access modifier if missing."
+        },
+        "tsco.addRegionIndentation": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds region Indentation."
+        },
+        "tsco.addRegionCaptionToRegionEnd": {
+          "type": "boolean",
+          "default": true,
+          "description": "Adds region caption to region end."
+        },
+        "tsco.groupPropertiesWithDecorators": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true properties with decorators will come first."
+        },
+        "tsco.treatArrowFunctionPropertiesAsMethods": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true arrow function properties will be treated as methods."
+        },
+        "tsco.memberOrder": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "member group",
+            "properties": {
+              "caption": {
+                "type": "string",
+                "description": "Group caption (outputted in the region name if this group is a region and if using regions)."
+              },
+              "memberTypes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Type of the member (avoid using duplicated member types).",
+                  "enum": [
+                    "privateStaticConstProperties",
+                    "privateConstProperties",
+                    "privateStaticReadOnlyProperties",
+                    "privateReadOnlyProperties",
+                    "privateStaticProperties",
+                    "privateProperties",
+                    "protectedStaticConstProperties",
+                    "protectedConstProperties",
+                    "protectedStaticReadOnlyProperties",
+                    "protectedReadOnlyProperties",
+                    "protectedStaticProperties",
+                    "protectedProperties",
+                    "publicStaticConstProperties",
+                    "publicConstProperties",
+                    "publicStaticReadOnlyProperties",
+                    "publicReadOnlyProperties",
+                    "publicStaticProperties",
+                    "publicProperties",
+                    "constructors",
+                    "publicStaticIndexes",
+                    "publicIndexes",
+                    "publicAbstractIndexes",
+                    "protectedStaticIndexes",
+                    "protectedIndexes",
+                    "protectedAbstractIndexes",
+                    "privateStaticIndexes",
+                    "privateIndexes",
+                    "privateAbstractIndexes",
+                    "publicStaticMethods",
+                    "publicMethods",
+                    "publicAbstractMethods",
+                    "protectedStaticMethods",
+                    "protectedMethods",
+                    "protectedAbstractMethods",
+                    "privateStaticMethods",
+                    "privateMethods",
+                    "privateAbstractMethods"
+                  ]
+                }
+              },
+              "default": [],
+              "description": "Nested member type sub-groups."
+            }
+          },
+          "default": [
             {
-                "command": "tsco.organize",
-                "title": "Organize Current File",
-                "category": "TypeScript Class Organizer",
-                "when": "editorTextFocus && editorLangId == typescript"
+              "caption": "Properties",
+              "memberTypes": [
+                "privateStaticConstProperties",
+                "privateConstProperties",
+                "privateStaticReadOnlyProperties",
+                "privateReadOnlyProperties",
+                "privateStaticProperties",
+                "privateProperties",
+                "protectedStaticConstProperties",
+                "protectedConstProperties",
+                "protectedStaticReadOnlyProperties",
+                "protectedReadOnlyProperties",
+                "protectedStaticProperties",
+                "protectedProperties",
+                "publicStaticConstProperties",
+                "publicConstProperties",
+                "publicStaticReadOnlyProperties",
+                "publicReadOnlyProperties",
+                "publicStaticProperties",
+                "publicProperties"
+              ]
             },
             {
-                "command": "tsco.organizeAll",
-                "title": "Organize All Files",
-                "category": "TypeScript Class Organizer"
-            }
-        ],
-        "menus": {
-            "editor/context": [
-                {
-                    "command": "tsco.organize",
-                    "group": "1_modification",
-                    "when": "editorTextFocus && editorLangId == typescript"
-                }
-            ]
-        },
-        "keybindings": [
+              "caption": "Constructors",
+              "memberTypes": [
+                "constructors"
+              ]
+            },
             {
-                "command": "tsco.organize",
-                "key": "ctrl+shift+o",
-                "mac": "cmd+shift+o",
-                "when": "editorTextFocus && editorLangId == typescript"
-            }
-        ],
-        "languages": [
+              "caption": "Public Static Indexers",
+              "memberTypes": [
+                "publicStaticIndexes"
+              ]
+            },
             {
-                "id": "typescript",
-                "extensions": [
-                    ".ts"
-                ]
+              "caption": "Public Indexers",
+              "memberTypes": [
+                "publicIndexes"
+              ]
+            },
+            {
+              "caption": "Public Abstract Indexers",
+              "memberTypes": [
+                "publicAbstractIndexes"
+              ]
+            },
+            {
+              "caption": "Protected Static Indexers",
+              "memberTypes": [
+                "protectedStaticIndexes"
+              ]
+            },
+            {
+              "caption": "Protected Indexers",
+              "memberTypes": [
+                "protectedIndexes"
+              ]
+            },
+            {
+              "caption": "Protected Abstract Indexers",
+              "memberTypes": [
+                "protectedAbstractIndexes"
+              ]
+            },
+            {
+              "caption": "Private Static Indexers",
+              "memberTypes": [
+                "privateStaticIndexes"
+              ]
+            },
+            {
+              "caption": "Private Indexers",
+              "memberTypes": [
+                "privateIndexes"
+              ]
+            },
+            {
+              "caption": "Private Abstract Indexers",
+              "memberTypes": [
+                "privateAbstractIndexes"
+              ]
+            },
+            {
+              "caption": "Public Static Accessors",
+              "memberTypes": [
+                "publicStaticGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Public Accessors",
+              "memberTypes": [
+                "publicGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Public Abstract Accessors",
+              "memberTypes": [
+                "publicAbstractGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Protected Static Accessors",
+              "memberTypes": [
+                "protectedStaticGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Protected Accessors",
+              "memberTypes": [
+                "protectedGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Protected Abstract Accessors",
+              "memberTypes": [
+                "protectedAbstractGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Private Static Accessors",
+              "memberTypes": [
+                "privateStaticGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Private Accessors",
+              "memberTypes": [
+                "privateGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Private Abstract Accessors",
+              "memberTypes": [
+                "privateAbstractGettersAndSetters"
+              ]
+            },
+            {
+              "caption": "Public Static Methods",
+              "memberTypes": [
+                "publicStaticMethods"
+              ]
+            },
+            {
+              "caption": "Public Methods",
+              "memberTypes": [
+                "publicMethods"
+              ]
+            },
+            {
+              "caption": "Public Abstract Methods",
+              "memberTypes": [
+                "publicAbstractMethods"
+              ]
+            },
+            {
+              "caption": "Protected Static Methods",
+              "memberTypes": [
+                "protectedStaticMethods"
+              ]
+            },
+            {
+              "caption": "Protected Methods",
+              "memberTypes": [
+                "protectedMethods"
+              ]
+            },
+            {
+              "caption": "Protected Abstract Methods",
+              "memberTypes": [
+                "protectedAbstractMethods"
+              ]
+            },
+            {
+              "caption": "Private Static Methods",
+              "memberTypes": [
+                "privateStaticMethods"
+              ]
+            },
+            {
+              "caption": "Private Methods",
+              "memberTypes": [
+                "privateMethods"
+              ]
+            },
+            {
+              "caption": "Private Abstract Methods",
+              "memberTypes": [
+                "privateAbstractMethods"
+              ]
             }
+          ],
+          "description": "Order of member types."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "tsco.organize",
+        "title": "Organize Current File",
+        "category": "TypeScript Class Organizer",
+        "when": "editorTextFocus && editorLangId == typescript"
+      },
+      {
+        "command": "tsco.organizeAll",
+        "title": "Organize All Files",
+        "category": "TypeScript Class Organizer"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "tsco.organize",
+          "group": "1_modification",
+          "when": "editorTextFocus && editorLangId == typescript"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "tsco.organize",
+        "key": "ctrl+shift+o",
+        "mac": "cmd+shift+o",
+        "when": "editorTextFocus && editorLangId == typescript"
+      }
+    ],
+    "languages": [
+      {
+        "id": "typescript",
+        "extensions": [
+          ".ts"
         ]
-    },
-    "main": "./out/extension.js",
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test",
-        "package": "npx vsce package"
-    },
-    "devDependencies": {
-        "@types/mocha": "5.2.7",
-        "@types/node": "12.7.5",
-        "eslint": "6.4.0",
-        "tslint": "5.20.0",
-        "vscode": "1.1.36"
-    },
-    "dependencies": {
-        "typescript": "^3.8.3"
-    }
+      }
+    ]
+  },
+  "main": "./out/extension",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "@types/mocha": "7.0.2",
+    "@types/node": "13.9.0",
+    "eslint": "6.8.0",
+    "vscode": "1.1.36"
+  },
+  "dependencies": {
+    "typescript": "3.8.3"
+  }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,6 @@
+import { ElementNodeGroupConfiguration } from './element-node-group-configuration';
+
+export class Configuration {
+    constructor(public readonly useRegions: boolean, public readonly addPublicModifierIfMissing: boolean, public readonly accessorsBeforeConstructor: boolean, public readonly addRowNumberInRegionName: boolean, public readonly addRegionIndentation: boolean, public readonly addRegionCaptionToRegionEnd: boolean, public readonly groupPropertiesWithDecorators: boolean, public readonly treatArrowFunctionPropertiesAsMethods: boolean, public readonly memberOrder: ElementNodeGroupConfiguration[]) {
+    }
+}

--- a/src/elements/method-node.ts
+++ b/src/elements/method-node.ts
@@ -12,7 +12,7 @@ export class MethodNode extends ElementNode
 
 	// #region Constructors (1)
 
-	constructor(sourceFile: ts.SourceFile, methodDeclaration: ts.MethodDeclaration)
+	constructor(sourceFile: ts.SourceFile, methodDeclaration: ts.MethodDeclaration | ts.PropertyDeclaration)
 	{
 		super(methodDeclaration);
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -82,7 +82,7 @@ export class Transformer
                     if (treatArrowFunctionPropertiesAsMethods &&
                         member.initializer?.kind === ts.SyntaxKind.ArrowFunction)
                     {
-                        (<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
+                        (<ClassNode>elements[elements.length - 1]).methods.push(new PropertyNode(sourceFile, member));
                     }
                     else
                     {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,126 +1,130 @@
-import * as ts from "typescript";
-import { ClassNode } from "./elements/class-node";
-import { ConstructorNode } from "./elements/constructor-node";
-import { ElementNode } from "./elements/element-node";
-import { EnumNode } from "./elements/enum-node";
-import { FunctionNode } from "./elements/function-node";
-import { GetterNode } from "./elements/getter-node";
-import { ImportNode } from "./elements/import-node";
-import { IndexNode } from "./elements/index-node";
-import { IndexSignatureNode } from "./elements/index-signature-node";
-import { InterfaceNode } from "./elements/interface-node";
-import { MethodNode } from "./elements/method-node";
-import { MethodSignatureNode } from "./elements/method-signature-node";
-import { PropertyNode } from "./elements/property-node";
-import { PropertySignatureNode } from "./elements/property-signature-node";
-import { SetterNode } from "./elements/setter-node";
-import { TypeAliasNode } from "./elements/type-alias-node";
+import { ClassNode } from './elements/class-node';
+import { ConstructorNode } from './elements/constructor-node';
+import { ElementNode } from './elements/element-node';
+import { EnumNode } from './elements/enum-node';
+import { FunctionNode } from './elements/function-node';
+import { GetterNode } from './elements/getter-node';
+import { ImportNode } from './elements/import-node';
+import { IndexNode } from './elements/index-node';
+import { IndexSignatureNode } from './elements/index-signature-node';
+import { InterfaceNode } from './elements/interface-node';
+import { MethodNode } from './elements/method-node';
+import { MethodSignatureNode } from './elements/method-signature-node';
+import { PropertyNode } from './elements/property-node';
+import { PropertySignatureNode } from './elements/property-signature-node';
+import { SetterNode } from './elements/setter-node';
+import { TypeAliasNode } from './elements/type-alias-node';
+import * as ts from 'typescript';
 
 export class Transformer
 {
-	// #region Public Methods (1)
+    // #region Public Methods (1)
 
-	public analyzeSyntaxTree(sourceFile: ts.SourceFile)
-	{
-		let elements: ElementNode[] = [];
+    public analyzeSyntaxTree(sourceFile: ts.SourceFile, treatArrowFunctionPropertiesAsMethods: boolean)
+    {
+        let elements: ElementNode[] = [];
 
-		// analyze ast
-		for (let node of sourceFile.getChildren(sourceFile))
-		{
-			this.visitSyntaxTree(elements, node, sourceFile);
-		}
+        // analyze ast
+        for (let node of sourceFile.getChildren(sourceFile))
+        {
+            this.visitSyntaxTree(elements, node, sourceFile, treatArrowFunctionPropertiesAsMethods);
+        }
 
-		return elements;
-	}
+        return elements;
+    }
 
-	// #endregion
+    // #endregion
 
-	// #region Private Methods (1)
+    // #region Private Methods (1)
 
-	private visitSyntaxTree(elements: ElementNode[], node: ts.Node, sourceFile: ts.SourceFile)
-	{
-		if (ts.isImportDeclaration(node))
-		{
-			elements.push(new ImportNode(sourceFile, node));
-		}
-		if (ts.isTypeAliasDeclaration(node))
-		{
-			elements.push(new TypeAliasNode(sourceFile, node));
-		}
-		else if (ts.isInterfaceDeclaration(node))
-		{
-			elements.push(new InterfaceNode(sourceFile, node));
+    private visitSyntaxTree(elements: ElementNode[], node: ts.Node, sourceFile: ts.SourceFile, treatArrowFunctionPropertiesAsMethods: boolean)
+    {
+        if (ts.isImportDeclaration(node))
+        {
+            elements.push(new ImportNode(sourceFile, node));
+        }
+        if (ts.isTypeAliasDeclaration(node))
+        {
+            elements.push(new TypeAliasNode(sourceFile, node));
+        }
+        else if (ts.isInterfaceDeclaration(node))
+        {
+            elements.push(new InterfaceNode(sourceFile, node));
 
-			for (let member of node.members)
-			{
-				if (ts.isPropertySignature(member))
-				{
-					(<InterfaceNode>elements[elements.length - 1]).properties.push(new PropertySignatureNode(sourceFile, member));
-				}
-				else if (ts.isIndexSignatureDeclaration(member))
-				{
-					(<InterfaceNode>elements[elements.length - 1]).indexes.push(new IndexSignatureNode(sourceFile, member));
-				}
-				else if (ts.isMethodSignature(member))
-				{
-					(<InterfaceNode>elements[elements.length - 1]).methods.push(new MethodSignatureNode(sourceFile, member));
-				}
-			}
-		}
-		else if (ts.isClassDeclaration(node))
-		{
-			elements.push(new ClassNode(sourceFile, node));
+            for (let member of node.members)
+            {
+                if (ts.isPropertySignature(member))
+                {
+                    (<InterfaceNode>elements[elements.length - 1]).properties.push(new PropertySignatureNode(sourceFile, member));
+                }
+                else if (ts.isIndexSignatureDeclaration(member))
+                {
+                    (<InterfaceNode>elements[elements.length - 1]).indexes.push(new IndexSignatureNode(sourceFile, member));
+                }
+                else if (ts.isMethodSignature(member))
+                {
+                    (<InterfaceNode>elements[elements.length - 1]).methods.push(new MethodSignatureNode(sourceFile, member));
+                }
+            }
+        }
+        else if (ts.isClassDeclaration(node))
+        {
+            elements.push(new ClassNode(sourceFile, node));
 
-			for (let member of node.members)
-			{
-				if (ts.isConstructorDeclaration(member))
-				{
-					(<ClassNode>elements[elements.length - 1]).constructors.push(new ConstructorNode(sourceFile, member));
-				}
-				else if (ts.isPropertyDeclaration(member))
-				{
-					if ( member.initializer?.kind === ts.SyntaxKind.ArrowFunction) {
-						(<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
-					} else {
-						(<ClassNode>elements[elements.length - 1]).properties.push(new PropertyNode(sourceFile, member));
-					}
-				}
-				else if (ts.isGetAccessorDeclaration(member))
-				{
-					(<ClassNode>elements[elements.length - 1]).getters.push(new GetterNode(sourceFile, member));
-				}
-				else if (ts.isSetAccessorDeclaration(member))
-				{
-					(<ClassNode>elements[elements.length - 1]).setters.push(new SetterNode(sourceFile, member));
-				}
-				else if (ts.isMethodDeclaration(member))
-				{
-					(<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
-				}
-				else if (ts.isIndexedAccessTypeNode(member))
-				{
-					(<ClassNode>elements[elements.length - 1]).indexes.push(new IndexNode(sourceFile, member));
-				}
-			}
-		}
-		else if (ts.isEnumDeclaration(node))
-		{
-			elements.push(new EnumNode(sourceFile, node));
-		}
-		else if (ts.isFunctionDeclaration(node))
-		{
-			elements.push(new FunctionNode(sourceFile, node));
-		}
-		else
-		{
-			for (let childNode of node.getChildren(sourceFile))
-			{
-				this.visitSyntaxTree(elements, childNode, sourceFile);
-			}
-		}
+            for (let member of node.members)
+            {
+                if (ts.isConstructorDeclaration(member))
+                {
+                    (<ClassNode>elements[elements.length - 1]).constructors.push(new ConstructorNode(sourceFile, member));
+                }
+                else if (ts.isPropertyDeclaration(member))
+                {
+                    if (treatArrowFunctionPropertiesAsMethods &&
+                        member.initializer?.kind === ts.SyntaxKind.ArrowFunction)
+                    {
+                        (<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
+                    }
+                    else
+                    {
+                        (<ClassNode>elements[elements.length - 1]).properties.push(new PropertyNode(sourceFile, member));
+                    }
+                }
+                else if (ts.isGetAccessorDeclaration(member))
+                {
+                    (<ClassNode>elements[elements.length - 1]).getters.push(new GetterNode(sourceFile, member));
+                }
+                else if (ts.isSetAccessorDeclaration(member))
+                {
+                    (<ClassNode>elements[elements.length - 1]).setters.push(new SetterNode(sourceFile, member));
+                }
+                else if (ts.isMethodDeclaration(member))
+                {
+                    (<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
+                }
+                else if (ts.isIndexedAccessTypeNode(member))
+                {
+                    (<ClassNode>elements[elements.length - 1]).indexes.push(new IndexNode(sourceFile, member));
+                }
+            }
+        }
+        else if (ts.isEnumDeclaration(node))
+        {
+            elements.push(new EnumNode(sourceFile, node));
+        }
+        else if (ts.isFunctionDeclaration(node))
+        {
+            elements.push(new FunctionNode(sourceFile, node));
+        }
+        else
+        {
+            for (let childNode of node.getChildren(sourceFile))
+            {
+                this.visitSyntaxTree(elements, childNode, sourceFile, treatArrowFunctionPropertiesAsMethods);
+            }
+        }
 
-		return elements;
-	}
+        return elements;
+    }
 
-	// #endregion
+    // #endregion
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -79,7 +79,11 @@ export class Transformer
 				}
 				else if (ts.isPropertyDeclaration(member))
 				{
-					(<ClassNode>elements[elements.length - 1]).properties.push(new PropertyNode(sourceFile, member));
+					if ( member.initializer?.kind === ts.SyntaxKind.ArrowFunction) {
+						(<ClassNode>elements[elements.length - 1]).methods.push(new MethodNode(sourceFile, member));
+					} else {
+						(<ClassNode>elements[elements.length - 1]).properties.push(new PropertyNode(sourceFile, member));
+					}
 				}
 				else if (ts.isGetAccessorDeclaration(member))
 				{


### PR DESCRIPTION
Changed transformer.ts so that it does an additional check when it is analysing the source tree and encounters a PropertyDeclaration.  These have further information include an *initializer* property, which if populated has a *kind* property.  If this is equivalent to SyntaxKind.ArrowFunction the member is added to the methods collection rather than the properties collection, and subsequently is organised along with methods.