### PR TITLE
prevent organizeOnSave from being triggered by events from autosave.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -27,7 +27,8 @@ export function activate(context: vscode.ExtensionContext)
 
     vscode.workspace.onWillSaveTextDocument(e =>
     {
-        if (vscode.window.activeTextEditor &&
+        if (e.reason === vscode.TextDocumentSaveReason.Manual && 
+            vscode.window.activeTextEditor &&
             vscode.window.activeTextEditor.document.fileName == e.document.fileName)
         {
             if (configuration.organizeOnSave)


### PR DESCRIPTION
Currently, when organizeOnSave is true with autosave is enabled, the files will be formatted on every change. I think it is obvious that we should prevent formatting files on change. Therefore i'd like to propose this extra check before organizing a file.